### PR TITLE
[top-pool-author] enable direct calls if compiled in offchain-worker mode

### DIFF
--- a/core-primitives/top-pool-author/src/author.rs
+++ b/core-primitives/top-pool-author/src/author.rs
@@ -50,8 +50,11 @@ use std::{boxed::Box, sync::Arc, vec::Vec};
 /// Define type of TOP filter that is used in the Author
 #[cfg(feature = "sidechain")]
 pub type AuthorTopFilter = crate::top_filter::CallsOnlyFilter;
+
+// This is different from upstream, direct calls are ok in the OLI case, as they
+//  come from a centralized instance.
 #[cfg(feature = "offchain-worker")]
-pub type AuthorTopFilter = crate::top_filter::IndirectCallsOnlyFilter;
+pub type AuthorTopFilter = crate::top_filter::CallsOnlyFilter;
 #[cfg(feature = "teeracle")] // Teeracle currently does not process any trusted operations
 pub type AuthorTopFilter = crate::top_filter::DenyAllFilter;
 


### PR DESCRIPTION
Upstream this is disable by default.

Until now, you have been using indirect invocation, aka your CLI send the request to the integritee-node and then it was forwarded to the worker. However, in this project we want to directly call the worker from the client, but it needs to disable the filter.

From now on, you can simply add `--direct` to the cli and the worker will immediately execute the trusted call, e.g.

```
/integritee-cli trusted --mrenclave CqLtrZvbCLMDHLecyjzTntNWDon8cbDcqySLpSK11aqS --direct pay-as-bid //Alice ./orders/order_10_users.json
```